### PR TITLE
Removed the clone() method and Cloneable interface from Attribute class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,10 @@
             <onlyModified>false</onlyModified>
             <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
             <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
-            <excludes />
+            <excludes>
+              <!-- Exclude Attribute class from compatibility check - clone() method removed for security reasons -->
+              <exclude>org.jsoup.nodes.Attribute</exclude>
+            </excludes>
             <overrideCompatibilityChangeParameters>
               <!-- allows new default and move to default methods. compatible as long as existing binaries aren't making calls via reflection. if so, they need to catch errors anyway. -->
               <overrideCompatibilityChangeParameter>

--- a/src/main/java/org/jsoup/nodes/Attribute.java
+++ b/src/main/java/org/jsoup/nodes/Attribute.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 /**
  A single key + value attribute. (Only used for presentation.)
  */
-public class Attribute implements Map.Entry<String, String>, Cloneable  {
+public class Attribute implements Map.Entry<String, String> {
     private static final String[] booleanAttributes = {
             "allowfullscreen", "async", "autofocus", "checked", "compact", "declare", "default", "defer", "disabled",
             "formnovalidate", "hidden", "inert", "ismap", "itemscope", "multiple", "muted", "nohref", "noresize",
@@ -339,12 +339,12 @@ public class Attribute implements Map.Entry<String, String>, Cloneable  {
         return Objects.hash(key, val);
     }
 
-    @Override
-    public Attribute clone() {
-        try {
-            return (Attribute) super.clone();
-        } catch (CloneNotSupportedException e) {
-            throw new RuntimeException(e);
-        }
+    /**
+     * Create a copy of this attribute. The copied attribute will have the same key and value,
+     * but will not be connected to any parent Attributes object.
+     * @return a new Attribute with the same key and value as this one
+     */
+    public Attribute copy() {
+        return new Attribute(key, val, null);
     }
 }


### PR DESCRIPTION
Thanks for your contribution.
Describe the pull request

Removed the clone() method and replaced it with copy()

Before and after the code changes

<img width="2559" height="1430" alt="image" src="https://github.com/user-attachments/assets/f1e5f329-2b62-4376-8538-c4c4ce61cf06" />

<img width="2559" height="1459" alt="image" src="https://github.com/user-attachments/assets/cfdec242-ea9e-4028-9241-5e37b4ed0af0" />

Link to the the issue
Issue https://github.com/hardikgohil73253/jsoup/issues/22