### PR TITLE
Fix Weak Cryptography hotspot in DataUtil.mimeBoundary()

### DIFF
--- a/src/main/java/org/jsoup/helper/DataUtil.java
+++ b/src/main/java/org/jsoup/helper/DataUtil.java
@@ -35,6 +35,8 @@ import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
+import java.security.SecureRandom;
+
 
 import static org.jsoup.internal.SharedConstants.DefaultBufferSize;
 
@@ -51,6 +53,8 @@ public final class DataUtil {
     private static final char[] mimeBoundaryChars =
             "-_1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
     static final int boundaryLength = 32;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
 
     private DataUtil() {}
 
@@ -384,9 +388,9 @@ public final class DataUtil {
      */
     static String mimeBoundary() {
         final StringBuilder mime = StringUtil.borrowBuilder();
-        final Random rand = new Random();
+
         for (int i = 0; i < boundaryLength; i++) {
-            mime.append(mimeBoundaryChars[rand.nextInt(mimeBoundaryChars.length)]);
+            mime.append(mimeBoundaryChars[SECURE_RANDOM.nextInt(mimeBoundaryChars.length)]);
         }
         return StringUtil.releaseBuilder(mime);
     }


### PR DESCRIPTION
Replaced java.util.Random with SecureRandom in DataUtil.mimeBoundary() to resolve SonarQube Weak Cryptography hotspot.
After applying the fix and rerunning SonarQube analysis, the Weak Cryptography hotspot no longer appears under Security Hotspots, confirming the issue is [resolved.]
<img width="893" height="329" alt="SonarQube_After" src="https://github.com/user-attachments/assets/bdf773d4-778c-458c-af9b-60130d1a2b5f" />

Closes https://github.com/hardikgohil73253/jsoup/issues/26